### PR TITLE
Merge recipe and item list on items page

### DIFF
--- a/src/js/controllers/item-bps-ctrl.js
+++ b/src/js/controllers/item-bps-ctrl.js
@@ -1,72 +1,14 @@
-﻿angular.module("RustCalc").controller("ItemBPsController", ["$scope", "$filter", "$rustData", "$rootScope", "$state", ItemBPsController]);
+﻿angular.module("RustCalc").controller("ItemBPsController", ["$scope", "$rustData", "$rootScope", "$stateParams", ItemBPsController]);
 
-function ItemBPsController ($scope, $filter, $rustData, $rootScope, $state)
+function ItemBPsController($scope, $rustData, $rootScope, $stateParams)
 {
     $rootScope.page.titlePrefix = "Items & Blueprints";
 
-    $scope.blueprintFilter =
-    {
-        name: ""
-    };
-
-    $scope.itemFilter = {
-        name: ""
-    };
-
-    $scope.filteredRecipes = [];
-    $scope.filteredItems = [];
-
-    function applyRecipeFilter()
-    {
-        if (typeof $scope.rustData == "undefined")
-            return;
-
-        var blueprints = Object.values($scope.rustData.recipes);
-        blueprints = blueprints.filter($scope.filterBlueprints);
-        blueprints = $filter("orderBy")(blueprints, "output.item.name");
-
-        $scope.filteredRecipes = blueprints;
-        $(".blueprint-browser .browser-wrapper").scrollTop(0); // Reset scroll position to top of list.
-    }
-
-    function applyItemFilter ()
-    {
-        if (typeof $scope.rustData == "undefined")
-            return;
-
-        var items = $scope.itemsArray.filter($scope.filterItems);
-        items = $filter("orderBy")(items, "name");
-
-        $scope.filteredItems = items;
-        $(".item-browser .browser-wrapper").scrollTop(0); // Reset scroll position to top of list.
-    }
-
-    $scope.$watch("blueprintFilter", applyRecipeFilter, true);
-    $scope.$watch("itemFilter", applyItemFilter, true);
-
-    $scope.filterBlueprints = function (recipe)
-    {
-        return recipe.output.item.name.toLowerCase().indexOf($scope.blueprintFilter.name.toLowerCase()) != -1;
-    };
-    
-    $scope.filterItems = function (item)
-    {
-        return item.name.toLowerCase().indexOf($scope.itemFilter.name.toLowerCase()) != -1;
-    };
-    
-    $scope.bpActive = function (recipe)
-    {
-        return $scope.stateParams.id == recipe.output.item.id && ($state.includes("itembps.item.recipe") || $state.includes("itembps.item.recipes"));
-    }
+    $scope.items = Object.values($rustData.items);
+    $scope.recipes = $rustData.recipes;
 
     $scope.itemActive = function (item)
     {
-        return $scope.stateParams.id == item.id && $state.includes("itembps.item.info");
-    }
-
-    $scope.rustData = $rustData;
-    $scope.itemsArray = Object.keys($rustData.items).map(function (key) { return $rustData.items[key]; });
-
-    applyRecipeFilter();
-    applyItemFilter();
+        return $stateParams.id === item.id;
+    };
 }

--- a/src/js/controllers/item-bps-ctrl.js
+++ b/src/js/controllers/item-bps-ctrl.js
@@ -1,6 +1,6 @@
-﻿angular.module("RustCalc").controller("ItemBPsController", ["$scope", "$rustData", "$rootScope", "$stateParams", ItemBPsController]);
+﻿angular.module("RustCalc").controller("ItemBPsController", ["$scope", "$rustData", "$rootScope", ItemBPsController]);
 
-function ItemBPsController($scope, $rustData, $rootScope, $stateParams)
+function ItemBPsController($scope, $rustData, $rootScope)
 {
     $rootScope.page.titlePrefix = "Items & Blueprints";
 
@@ -9,6 +9,6 @@ function ItemBPsController($scope, $rustData, $rootScope, $stateParams)
 
     $scope.itemActive = function (item)
     {
-        return $stateParams.id === item.id;
+        return $scope.stateParams.id === item.id;
     };
 }

--- a/src/scss/ui.scss
+++ b/src/scss/ui.scss
@@ -106,7 +106,7 @@ div.main-ui
             height: calc(100% - 84px);
 
             width: 500px;
-            
+
             overflow: hidden;
 
             & a:last-child .item-row
@@ -114,15 +114,10 @@ div.main-ui
                 margin-bottom: 0;
             }
 
-            & a > .item-row
-            {
-                color: $textColor;
-            }
-
             & .item-row
             {
-                width: 100%;
                 height: 80px;
+                cursor: pointer;
                 margin-bottom: 5px;
                 background-color: rgba(255, 255, 255, 0.15);
                 overflow: hidden;
@@ -142,17 +137,14 @@ div.main-ui
                 {
                     background-color: rgba(160, 255, 160, 0.2);
                 }
-                
+
                 & .image
                 {
                     float: left;
                     padding: 10px;
                     text-align: center;
-
-                    & > img
-                    {
-                        width: 60px;
-                    }
+                    width: 60px;
+                    height: 60px;
                 }
 
                 & .info
@@ -183,81 +175,6 @@ div.main-ui
             {
                 height: 20px;
             }
-        }
-    }
-
-    & .blueprint-browser
-    {
-        position: absolute;
-        right: 0;
-        top: 0;
-        bottom: 0;
-        margin: 0 40px 40px 0;
-        text-align: right;
-
-        & > .categories-title
-        {
-            text-align: left;
-            font-family: Coolvetica;
-        }
-
-        & > .categories
-        {
-            background-color: rgba(255, 255, 255, 0.15);
-            text-align: left;
-            margin-bottom: 5px;
-            
-            & > .category
-            {
-                position: relative;
-                cursor: pointer;
-                display: inline-block;
-                padding: 5px 15px;
-
-                -moz-filter: grayscale(100%);
-                -webkit-filter: grayscale(100%);
-                filter: grayscale(100%);
-                opacity: 0.75;
-
-                & > img
-                {
-                    width: 50px;
-                    vertical-align: middle;
-                }
-
-                & > input[type=checkbox]
-                {
-                    position: absolute;
-                    top: 0;
-                    right: 0;
-                    margin: 2px 2px 0 0;
-                    display: none;
-                }
-
-                &:hover > input[type=checkbox]
-                {
-                    display: inline;
-                }
-
-                &:hover
-                {
-                    background-color: rgba(255, 255, 255, 0.1);
-                }
-
-                &.active
-                {
-                    -moz-filter: none;
-                    -webkit-filter: none;
-                    filter: none;
-                    opacity: 1;
-                }
-            }
-        }
-
-        & div.browser-wrapper
-        {
-            text-align: left; /* Reset text alignment */
-            height: calc(100% - 85px);
         }
     }
 

--- a/src/templates/itembps.html
+++ b/src/templates/itembps.html
@@ -4,52 +4,29 @@
         <span class="header large no-select">Items</span>
         <div class="searchbar">
             <span>Search:</span>
-            <input type="text" ng-model="itemFilter.name" />
+            <input type="text" ng-model="itemFilter" />
         </div>
+
         <perfect-scrollbar class="browser-wrapper scroller">
-            <a ui-sref="itembps.item.info({ id: item.id })" ng-repeat="item in filteredItems">
-                <div class="item clearfix item-row" ng-class="{ 'active': itemActive(item) }">
-                    <div class="image">
-                        <img ng-src="/img/icons/{{item.id}}_small.png" />
-                    </div>
+            <div ng-repeat="item in items | filter:{name: itemFilter} track by item.id">
+                <div ui-sref="itembps.item.info({ id: item.id })" class="item clearfix item-row" ng-class="{ 'active': itemActive(item) }">
+                    <img class="image" ng-src="/img/icons/{{::item.id}}_small.png" />
                     <div class="info">
-                        <span class="name">{{item.name}}</span>
+                        <span class="name">
+                            {{::item.name}}
+                        </span>
                         <br />
-                        <span class="description" title="{{item.description}}">{{item.description | limitLength: 61}}</span>
+                        <span class="description" title="{{::item.description}}">{{::item.description | limitLength: 61}}</span>
                     </div>
-                </div>
-            </a>
-        </perfect-scrollbar>
-    </div>
-    <div class="browser blueprint-browser">
-        <span class="header large no-select">Blueprints</span>
-        <div class="searchbar" style="text-align: left">
-            <span>Search:</span>
-            <input type="text" ng-model="blueprintFilter.name" />
-        </div>
-        <perfect-scrollbar class="browser-wrapper scroller">
-            <a ui-sref="itembps.item.recipe({ id: recipe.output.item.id, count: 1 })" ng-repeat="recipe in filteredRecipes">
-                <div class="blueprint clearfix item-row" ng-class="{ 'active': bpActive(recipe) }">
-                    <div class="image">
-                        <img ng-src="/img/icons/{{recipe.output.item.id}}_small.png" />
-                    </div>
-                    <div class="info">
-                        <span class="name">{{recipe.output.item.name}}</span>
-                        <br />
-                        <span class="description" title="{{recipe.input | friendlyRecipeInput}}">{{recipe.input | friendlyRecipeInput | limitLength: 65}}</span>
-                    </div>
-                    <div class="xp-info">
+                    <div class="xp-info" ng-if="recipes[item.id]">
+                        <a ui-sref="itembps.item.recipe({ id: item.id, count: 1 })" ng-if="recipes[item.id]" ng-click="$event.stopPropagation()">
+                            Recipe <i class="fa fa-flask"></i>
+                        </a>
+
                         <div class="box level" title="Level">
-                            <i class="fa fa-star"></i>
-                            {{recipe.level}}
+                            <i class="fa fa-star"></i> {{recipes[item.id].level}}
                         </div>
                     </div>
-                </div>
-            </a>
-            <div class="blueprint clearfix item-row" ng-show="!filteredRecipes.length">
-                <div class="image"></div>
-                <div class="info" style="margin-top: 0.6em">
-                    <span class="description">No items found with the current filter options.</span>
                 </div>
             </div>
         </perfect-scrollbar>


### PR DESCRIPTION
Fixes #5 

The new page:
![wvv6cok](https://cloud.githubusercontent.com/assets/597021/17270879/67f4b7c8-56c1-11e6-8f31-9d9f3e3b8b07.jpg)

I realised that it makes sense to merge the two lists before implementing categories. The code for the item page is much simpler now so categories will be very quick to implement.

I'm not sure about the link I added to the item, it adds a lot of clutter. A solution would be to merge the recipe/blueprint page and the info page for an item (since they are mostly the same), meaning we could remove the recipe link altogether.

I also used the beaker icon to indicate bp/recipe rather than the page icon which is being used on the item page, I think it conveys more meaning even though it isn't consistent.

